### PR TITLE
Make types accessible for other modules

### DIFF
--- a/internal/client/gandi.go
+++ b/internal/client/gandi.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"strings"
+
+	"github.com/go-gandi/go-gandi/types"
 )
 
 const (
@@ -135,7 +137,7 @@ func (g *Gandi) doAskGandi(method, path string, p interface{}, extraHeaders [][2
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		defer resp.Body.Close()
-		var message StandardResponse
+		var message types.StandardResponse
 		defer resp.Body.Close()
 		decoder := json.NewDecoder(resp.Body)
 		decoder.Decode(&message)
@@ -153,22 +155,4 @@ func (g *Gandi) doAskGandi(method, path string, p interface{}, extraHeaders [][2
 		}
 	}
 	return resp, err
-}
-
-// StandardResponse is a standard response
-type StandardResponse struct {
-	Code    int             `json:"code,omitempty"`
-	Message string          `json:"message,omitempty"`
-	UUID    string          `json:"uuid,omitempty"`
-	Object  string          `json:"object,omitempty"`
-	Cause   string          `json:"cause,omitempty"`
-	Status  string          `json:"status,omitempty"`
-	Errors  []StandardError `json:"errors,omitempty"`
-}
-
-// StandardError is embedded in a standard error
-type StandardError struct {
-	Location    string `json:"location"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
 }

--- a/livedns/domain.go
+++ b/livedns/domain.go
@@ -1,6 +1,8 @@
 package livedns
 
-import "github.com/go-gandi/go-gandi/internal/client"
+import (
+	"github.com/go-gandi/go-gandi/types"
+)
 
 // Domain represents a DNS domain
 type Domain struct {
@@ -32,7 +34,7 @@ func (g *LiveDNS) ListDomains() (domains []Domain, err error) {
 }
 
 // CreateDomain adds a domain to a zone
-func (g *LiveDNS) CreateDomain(fqdn string, ttl int) (response client.StandardResponse, err error) {
+func (g *LiveDNS) CreateDomain(fqdn string, ttl int) (response types.StandardResponse, err error) {
 	_, err = g.client.Post("domains", createDomainRequest{FQDN: fqdn, Zone: zone{TTL: ttl}}, &response)
 	return
 }
@@ -44,7 +46,7 @@ func (g *LiveDNS) GetDomain(fqdn string) (domain Domain, err error) {
 }
 
 // UpdateDomain changes the zone associated to a domain
-func (g *LiveDNS) UpdateDomain(fqdn string, details UpdateDomainRequest) (response client.StandardResponse, err error) {
+func (g *LiveDNS) UpdateDomain(fqdn string, details UpdateDomainRequest) (response types.StandardResponse, err error) {
 	_, err = g.client.Patch("domains/"+fqdn, details, &response)
 	return
 }

--- a/livedns/domainrecord.go
+++ b/livedns/domainrecord.go
@@ -1,6 +1,8 @@
 package livedns
 
-import "github.com/go-gandi/go-gandi/internal/client"
+import (
+	"github.com/go-gandi/go-gandi/types"
+)
 
 // DomainRecord represents a DNS Record
 type DomainRecord struct {
@@ -37,7 +39,7 @@ func (g *LiveDNS) GetDomainRecordByNameAndType(fqdn, name, recordtype string) (r
 }
 
 // CreateDomainRecord creates a record in the zone attached to a domain
-func (g *LiveDNS) CreateDomainRecord(fqdn, name, recordtype string, ttl int, values []string) (response client.StandardResponse, err error) {
+func (g *LiveDNS) CreateDomainRecord(fqdn, name, recordtype string, ttl int, values []string) (response types.StandardResponse, err error) {
 	_, err = g.client.Post("domains/"+fqdn+"/records",
 		DomainRecord{
 			RrsetType:   recordtype,
@@ -54,21 +56,21 @@ type itemsPrefixForZoneRecords struct {
 }
 
 // UpdateDomainRecords changes all records in the zone attached to a domain
-func (g *LiveDNS) UpdateDomainRecords(fqdn string, records []DomainRecord) (response client.StandardResponse, err error) {
+func (g *LiveDNS) UpdateDomainRecords(fqdn string, records []DomainRecord) (response types.StandardResponse, err error) {
 	prefixedRecords := itemsPrefixForZoneRecords{Items: records}
 	_, err = g.client.Put("domains/"+fqdn+"/records", prefixedRecords, &response)
 	return
 }
 
 // UpdateDomainRecordsByName changes all records with the given name in the zone attached to the domain
-func (g *LiveDNS) UpdateDomainRecordsByName(fqdn, name string, records []DomainRecord) (response client.StandardResponse, err error) {
+func (g *LiveDNS) UpdateDomainRecordsByName(fqdn, name string, records []DomainRecord) (response types.StandardResponse, err error) {
 	prefixedRecords := itemsPrefixForZoneRecords{Items: records}
 	_, err = g.client.Put("domains/"+fqdn+"/records/"+name, prefixedRecords, &response)
 	return
 }
 
 // UpdateDomainRecordByNameAndType changes the record with the given name and the given type in the zone attached to a domain
-func (g *LiveDNS) UpdateDomainRecordByNameAndType(fqdn, name, recordtype string, ttl int, values []string) (response client.StandardResponse, err error) {
+func (g *LiveDNS) UpdateDomainRecordByNameAndType(fqdn, name, recordtype string, ttl int, values []string) (response types.StandardResponse, err error) {
 	_, err = g.client.Put("domains/"+fqdn+"/records/"+name+"/"+recordtype,
 		DomainRecord{
 			RrsetType:   recordtype,

--- a/livedns/keys.go
+++ b/livedns/keys.go
@@ -1,6 +1,8 @@
 package livedns
 
-import "github.com/go-gandi/go-gandi/internal/client"
+import (
+	"github.com/go-gandi/go-gandi/types"
+)
 
 // SigningKey holds data about a DNSSEC signing key
 type SigningKey struct {
@@ -56,7 +58,7 @@ func (g *LiveDNS) GetDomainTSIGKeys(fqdn string) (response []TSIGKey, err error)
 }
 
 // AssociateTSIGKeyWithDomain retrieves the specified TSIG key
-func (g *LiveDNS) AssociateTSIGKeyWithDomain(fqdn string, id string) (response client.StandardResponse, err error) {
+func (g *LiveDNS) AssociateTSIGKeyWithDomain(fqdn string, id string) (response types.StandardResponse, err error) {
 	_, err = g.client.Put("domains/"+fqdn+"/axfr/tsig/"+id, nil, &response)
 	return
 }
@@ -68,7 +70,7 @@ func (g *LiveDNS) RemoveTSIGKeyFromDomain(fqdn string, id string) (err error) {
 }
 
 // SignDomain creates a DNSKEY and asks Gandi servers to automatically sign the domain
-func (g *LiveDNS) SignDomain(fqdn string) (response client.StandardResponse, err error) {
+func (g *LiveDNS) SignDomain(fqdn string) (response types.StandardResponse, err error) {
 	f := SigningKey{Flags: 257}
 	_, err = g.client.Post("domains/"+fqdn+"/keys", f, &response)
 	return

--- a/livedns/snapshots.go
+++ b/livedns/snapshots.go
@@ -1,9 +1,8 @@
 package livedns
 
 import (
+	"github.com/go-gandi/go-gandi/types"
 	"time"
-
-	"github.com/go-gandi/go-gandi/internal/client"
 )
 
 // Snapshot represents a point in time record of a domain
@@ -23,7 +22,7 @@ func (g *LiveDNS) ListSnapshots(fqdn string) (snapshots []Snapshot, err error) {
 }
 
 // CreateSnapshot creates a snapshot for a domain
-func (g *LiveDNS) CreateSnapshot(fqdn string) (response client.StandardResponse, err error) {
+func (g *LiveDNS) CreateSnapshot(fqdn string) (response types.StandardResponse, err error) {
 	_, err = g.client.Post("domains/"+fqdn+"/snapshots", nil, &response)
 	return
 }

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,19 @@
+package types
+
+// StandardResponse is a standard response
+type StandardResponse struct {
+	Code    int             `json:"code,omitempty"`
+	Message string          `json:"message,omitempty"`
+	UUID    string          `json:"uuid,omitempty"`
+	Object  string          `json:"object,omitempty"`
+	Cause   string          `json:"cause,omitempty"`
+	Status  string          `json:"status,omitempty"`
+	Errors  []StandardError `json:"errors,omitempty"`
+}
+
+// StandardError is embedded in a standard error
+type StandardError struct {
+	Location    string `json:"location"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}


### PR DESCRIPTION
This makes it possible to easily mock the client. At the moment that is a bit cumbersome as the types are internal.

I'm working to support gandi as a provider in https://github.com/kubernetes-sigs/external-dns. As some functions return the `StandardResponse` defined in `internal` I had to copy those structures to be able to mock the LiveDNS client.

See: https://github.com/packi/external-dns/blob/gandi-provider/provider/gandi/client.go

I don't know if this is the golang way to do things but I vaguely remember seeing other modules do something similar.