### PR TITLE
Fix some linting errors 

### DIFF
--- a/cmd/gandi.go
+++ b/cmd/gandi.go
@@ -66,7 +66,7 @@ func jsonPrint(data interface{}, err error) error {
 	return nil
 }
 
-func textPrint(data []byte, err error) error {
+func textPrint(data []byte, err error) error { //nolint
 	if err != nil {
 		return fmt.Errorf("Error: %w", err)
 	}

--- a/cmd/zonerecord.go
+++ b/cmd/zonerecord.go
@@ -43,12 +43,12 @@ func (d *liveDNSUpdateRecordCmd) Run(g *globals) error {
 	return jsonPrint(l.UpdateDomainRecordByNameAndType(fqdn, d.Name, d.Type, d.TTL, d.Values))
 }
 
-type liveDNSDeleteRecordCmd struct {
+type liveDNSDeleteRecordCmd struct { //nolint: unused
 	Name string `kong:"arg,optional,name='name',help='The name of the record to fetch'"`
 	Type string `kong:"arg,optional,help='The type of the record to retrieve. You must specify the name too.'"`
 }
 
-func (d *liveDNSDeleteRecordCmd) Run(g *globals) error {
+func (d *liveDNSDeleteRecordCmd) Run(g *globals) error { //nolint: unused
 	fqdn := c.LiveDNS.Manage.Name.Name
 	l := g.liveDNSHandle
 	if d.Name != "" && d.Type != "" {

--- a/internal/client/gandi.go
+++ b/internal/client/gandi.go
@@ -70,7 +70,9 @@ func (g *Gandi) askGandi(method, path string, params, recipient interface{}) (ht
 	}
 	defer resp.Body.Close()
 	decoder := json.NewDecoder(resp.Body)
-	decoder.Decode(recipient)
+	if err = decoder.Decode(recipient); err != nil {
+		return resp.Header, err
+	}
 	return resp.Header, nil
 }
 
@@ -138,7 +140,9 @@ func (g *Gandi) doAskGandi(method, path string, p interface{}, extraHeaders [][2
 		var message StandardResponse
 		defer resp.Body.Close()
 		decoder := json.NewDecoder(resp.Body)
-		decoder.Decode(&message)
+		if err = decoder.Decode(&message); err != nil {
+			return resp, err
+		}
 		if message.Message != "" {
 			err = fmt.Errorf("%d: %s", resp.StatusCode, message.Message)
 		} else if len(message.Errors) > 0 {


### PR DESCRIPTION
- Suppress a deadcode and unused lint error in cmd/zonerecord
- Fix "Error return value of `decoder.Decode` is not checked" by properly
  checking it
