### PR TITLE
Add support for the Simple Hosting product 

### DIFF
--- a/.github/workflows/lint_build.yaml
+++ b/.github/workflows/lint_build.yaml
@@ -24,10 +24,23 @@ jobs:
         with:
           extra_args: --all-files --show-diff-on-failure
 
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Test
+        run: |
+          go test -v ./...
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: lint
+    needs: test
     strategy:
       matrix:
         os_arch:
@@ -47,9 +60,3 @@ jobs:
           GOARCH=${GOOSARCH#*/}
           NAME=${{github.repository}}-$GOOS-$GOARCH
           GOOS=$GOOS GOARCH=$GOARCH go build -o $NAME -v
-      - name: Test
-        run: |
-          GOOSARCH=${{ matrix.os_arch }}
-          GOOS=${GOOSARCH%/*}
-          GOARCH=${GOOSARCH#*/}
-          GOOS=$GOOS GOARCH=$GOARCH go test -v ./...

--- a/cmd/gandi.go
+++ b/cmd/gandi.go
@@ -9,22 +9,25 @@ import (
 	"github.com/go-gandi/go-gandi"
 	"github.com/go-gandi/go-gandi/domain"
 	"github.com/go-gandi/go-gandi/livedns"
+	"github.com/go-gandi/go-gandi/simplehosting"
 )
 
 type cli struct {
 	globals
-	LiveDNS   liveDNSCmd `kong:"cmd,name='livedns',help='Manage LiveDNS'"`
-	Domain    domainCmd  `kong:"cmd,help='Manage Domains'"`
-	Debug     bool       `kong:"short='d',help='Enable debug logging'"`
-	DryRun    bool       `kong:"help='Enable dry run mode'"`
-	APIKey    string     `kong:"env='GANDI_KEY',help='The Gandi LiveDNS API key (may be stored in the GANDI_KEY environment variable)'"`
-	SharingID string     `kong:"short='i',env='GANDI_SHARING_ID',help='The Gandi LiveDNS sharingID (may be stored in the GANDI_SHARING_ID environment variable)'"`
+	LiveDNS       liveDNSCmd       `kong:"cmd,name='livedns',help='Manage LiveDNS'"`
+	Domain        domainCmd        `kong:"cmd,help='Manage Domains'"`
+	SimpleHosting simpleHostingCmd `kong:"cmd,help='Manage Simple Hosting'"`
+	Debug         bool             `kong:"short='d',help='Enable debug logging'"`
+	DryRun        bool             `kong:"help='Enable dry run mode'"`
+	APIKey        string           `kong:"env='GANDI_KEY',help='The Gandi LiveDNS API key (may be stored in the GANDI_KEY environment variable)'"`
+	SharingID     string           `kong:"short='i',env='GANDI_SHARING_ID',help='The Gandi LiveDNS sharingID (may be stored in the GANDI_SHARING_ID environment variable)'"`
 }
 
 type globals struct {
-	liveDNSHandle *livedns.LiveDNS
-	domainHandle  *domain.Domain
-	Version       versionFlag `kong:"name='version',help='Print version information and quit'"`
+	liveDNSHandle       *livedns.LiveDNS
+	domainHandle        *domain.Domain
+	simpleHostingHandle *simplehosting.SimpleHosting
+	Version             versionFlag `kong:"name='version',help='Print version information and quit'"`
 }
 
 var c cli
@@ -53,6 +56,7 @@ func main() {
 	}
 	c.globals.domainHandle = gandi.NewDomainClient(c.APIKey, g)
 	c.globals.liveDNSHandle = gandi.NewLiveDNSClient(c.APIKey, g)
+	c.globals.simpleHostingHandle = gandi.NewSimpleHostingClient(c.APIKey, g)
 	err := ctx.Run(&c.globals)
 	ctx.FatalIfErrorf(err)
 }

--- a/cmd/simplehosting.go
+++ b/cmd/simplehosting.go
@@ -1,0 +1,51 @@
+package main
+
+import "github.com/go-gandi/go-gandi/simplehosting"
+
+type simpleHostingCmd struct {
+	Instance instanceCmd `kong:"cmd,help='Simple Hosting instance commands'"`
+}
+
+type instanceCmd struct {
+	List   instanceListCmd   `kong:"cmd,help='List Simple Hosting instances'"`
+	Delete instanceDeleteCmd `kong:"cmd,help='Delete a Simple Hosting instance'"`
+	Create instanceCreateCmd `kong:"cmd,help='Create a Simple Hosting instance'"`
+}
+
+type instanceListCmd struct{}
+type instanceDeleteCmd struct {
+	InstanceId string `kong:"arg,help='The ID of a Simple Hosting instance'"`
+}
+type instanceCreateCmd struct {
+	Name     string `kong:"arg,help='The name of a Simple Hosting instance'"`
+	Location string `kong:"arg,help='The location of a Simple Hosting instance'"`
+	Database string `kong:"arg,help='The database type of a Simple Hosting instance'"`
+	Language string `kong:"arg,help='The language type of a Simple Hosting instance'"`
+}
+
+func (cmd *instanceListCmd) Run(g *globals) error {
+	s := g.simpleHostingHandle
+	return jsonPrint(s.ListInstances())
+}
+
+func (cmd *instanceDeleteCmd) Run(g *globals) error {
+	s := g.simpleHostingHandle
+	return jsonPrint(s.DeleteInstance(cmd.InstanceId))
+}
+
+func (cmd *instanceCreateCmd) Run(g *globals) error {
+	s := g.simpleHostingHandle
+	return jsonPrint(s.CreateInstance(
+		simplehosting.CreateInstanceRequest{
+			Name:     cmd.Name,
+			Location: cmd.Location,
+			Type: &simplehosting.InstanceType{
+				Database: &simplehosting.Database{
+					Name: cmd.Database,
+				},
+				Language: &simplehosting.Language{
+					Name: cmd.Language,
+				},
+			},
+		}))
+}

--- a/gandi.go
+++ b/gandi.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-gandi/go-gandi/domain"
 	"github.com/go-gandi/go-gandi/email"
 	"github.com/go-gandi/go-gandi/livedns"
+	"github.com/go-gandi/go-gandi/simplehosting"
 )
 
 // Config manages common config for all Gandi API types
@@ -32,4 +33,10 @@ func NewEmailClient(apikey string, config Config) *email.Email {
 // It expects an API key, available from https://account.gandi.net/en/
 func NewLiveDNSClient(apikey string, config Config) *livedns.LiveDNS {
 	return livedns.New(apikey, config.SharingID, config.Debug, config.DryRun)
+}
+
+// NewSimpleHostingClient returns a client to the Gandi Simple Hosting API
+// It expects an API key, available from https://account.gandi.net/en/
+func NewSimpleHostingClient(apikey string, config Config) *simplehosting.SimpleHosting {
+	return simplehosting.New(apikey, config.SharingID, config.Debug, config.DryRun)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.17
 
 require (
 	github.com/alecthomas/kong v0.2.2
+	gopkg.in/h2non/gock.v1 v1.1.2
 	moul.io/http2curl v1.0.0
 )
 
 require (
+	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/smartystreets/goconvey v1.7.2 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -25,6 +29,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/h2non/gock.v1 v1.1.2 h1:jBbHXgGBK/AoPVfJh5x4r/WxIrElvbLel8TCZkkZJoY=
+gopkg.in/h2non/gock.v1 v1.1.2/go.mod h1:n7UGz/ckNChHiK05rDoiC4MYSunEC/lyaUm2WWaDva0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 moul.io/http2curl v1.0.0 h1:6XwpyZOYsgZJrU8exnG87ncVkU1FVCcTRpwzOkTDUi8=

--- a/internal/client/gandi.go
+++ b/internal/client/gandi.go
@@ -36,6 +36,11 @@ func (g *Gandi) SetEndpoint(endpoint string) {
 	g.endpoint = gandiEndpoint + endpoint
 }
 
+// GetEndpoint gets the URL of the endpoint.
+func (g *Gandi) GetEndpoint() string {
+	return g.endpoint
+}
+
 // Get issues a GET request. It takes a subpath rooted in the endpoint. Response data is written to the recipient.
 // Returns the response headers and any error
 func (g *Gandi) Get(path string, params, recipient interface{}) (http.Header, error) {

--- a/internal/client/gandi.go
+++ b/internal/client/gandi.go
@@ -138,6 +138,12 @@ func (g *Gandi) doAskGandi(method, path string, p interface{}, extraHeaders [][2
 		log.Printf("Response : [%s] %s", resp.Status, header.String())
 		log.Printf("Response body: %s", string(body))
 	}
+	// Delete queries can return a 204 code. In this case, the
+	// body is empty. See for instance:
+	// https://api.gandi.net/docs/simplehosting/#delete-v5-simplehosting-instances-instance_id
+	if resp.StatusCode == 204 {
+		return resp.Header, []byte("{}"), err
+	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		var message types.StandardResponse
 

--- a/simplehosting/instance_test.go
+++ b/simplehosting/instance_test.go
@@ -1,0 +1,83 @@
+package simplehosting_test
+
+import (
+	"testing"
+
+	"github.com/go-gandi/go-gandi/simplehosting"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestDeleteInstance(t *testing.T) {
+	defer gock.Off()
+	instanceId := "23739138-4850-11ec-8973-00163ec4cb00"
+
+	gock.New("https://api.gandi.net/v5/").
+		Delete("/instances/" + instanceId).
+		Reply(204)
+
+	simpleHosting := simplehosting.New("", "", true, false)
+	response, err := simpleHosting.DeleteInstance(instanceId)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := simplehosting.ErrorResponse{}
+	if response != expected {
+		t.Fatalf("Response should be '%#v' (while it is %#v)", expected, response)
+	}
+}
+
+// TestCreateInstance tests the instance ID is correctly returned.
+func TestCreateInstance(t *testing.T) {
+	defer gock.Off()
+	instanceName := "new-instance"
+	expectedInstanceId := "23739138-4850-11ec-8973-00163ec4cb00"
+
+	gock.New("https://api.gandi.net/v5/").
+		Post("instances").
+		JSON(map[string]interface{}{
+			"name":     instanceName,
+			"location": "FR",
+			"type": map[string]interface{}{
+				"database": map[string]string{
+					"name":    "mysql",
+					"version": "",
+				},
+				"language": map[string]string{
+					"name":    "php",
+					"version": "",
+				},
+			},
+			"size": "",
+		}).
+		Reply(202).
+		SetHeader(
+			"Content-Location",
+			"https://api.gandi.net/v5/simplehosting/"+"instances/"+expectedInstanceId).
+		JSON(map[string]string{
+			"message": "Instance is being created",
+		})
+
+	simpleHosting := simplehosting.New("", "", true, false)
+	instanceId, err := simpleHosting.CreateInstance(
+		simplehosting.CreateInstanceRequest{
+			Name:     instanceName,
+			Location: "FR",
+			Type: &simplehosting.InstanceType{
+				Database: &simplehosting.Database{
+					Name: "mysql",
+				},
+				Language: &simplehosting.Language{
+					Name: "php",
+				},
+			},
+		},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instanceId != expectedInstanceId {
+		t.Fatalf("InstanceId should be '%s' (while it is %s)",
+			expectedInstanceId, instanceId)
+	}
+}

--- a/simplehosting/simplehosting.go
+++ b/simplehosting/simplehosting.go
@@ -1,0 +1,50 @@
+package simplehosting
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-gandi/go-gandi/internal/client"
+)
+
+// New returns an instance of the Simple Hosting API client
+func New(apikey string, sharingid string, debug bool, dryRun bool) *SimpleHosting {
+	client := client.New(apikey, sharingid, debug, dryRun)
+	client.SetEndpoint("simplehosting/")
+	return &SimpleHosting{client: *client}
+}
+
+// ListInstances requests the list of SimpleHosting instances
+func (g *SimpleHosting) ListInstances() (simplehostings []ListInstancesResponse, err error) {
+	_, err = g.client.Get("instances", nil, &simplehostings)
+	return
+}
+
+// GetInstance requests a single Instance
+func (g *SimpleHosting) GetInstance(instanceId string) (simplehostingResponse Instance, err error) {
+	_, err = g.client.Get("instances/"+instanceId, nil, &simplehostingResponse)
+	return
+}
+
+// CreateInstance creates a SimpleHosting instance
+func (g *SimpleHosting) CreateInstance(req CreateInstanceRequest) (instanceId string, err error) {
+	header, err := g.client.Post("instances", req, nil)
+	if err != nil {
+		return "", err
+	}
+	// We have to extract the instance ID from the
+	// Content-Location response header.
+	location := header.Get("Content-Location")
+	endpoint := g.client.GetEndpoint() + "instances/"
+	if strings.HasPrefix(location, endpoint) {
+		return strings.TrimPrefix(location, endpoint), nil
+	} else {
+		return "", fmt.Errorf("Could not extract the instance ID from '%s'", location)
+	}
+}
+
+// CreateInstance deletes a SimpleHosting instance
+func (g *SimpleHosting) DeleteInstance(instanceId string) (response ErrorResponse, err error) {
+	_, err = g.client.Delete("instances/"+instanceId, nil, &response)
+	return
+}

--- a/simplehosting/types.go
+++ b/simplehosting/types.go
@@ -1,0 +1,61 @@
+package simplehosting
+
+import (
+	"github.com/go-gandi/go-gandi/internal/client"
+)
+
+// SimpleHosting is the API client to the Gandi v5 Simple Hosting API
+type SimpleHosting struct {
+	client client.Gandi
+}
+
+// ListInstancesResponse is the response object returned by listing
+// simplehosting instances
+type ListInstancesResponse struct {
+	ID       string    `json:"id"`
+	Name     string    `json:"name"`
+	Size     string    `json:"size"`
+	Status   string    `json:"status"`
+	Database *Database `json:"database"`
+	Language *Language `json:"language"`
+}
+
+// Database represents the type of a Simple Hosting database
+type Database struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// Language represents the type of a Simple Hosting database
+type Language struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type Instance struct {
+	ID       string    `json:"id"`
+	Name     string    `json:"name"`
+	Size     string    `json:"size"`
+	Status   string    `json:"status"`
+	Database *Database `json:"database"`
+	Language *Language `json:"language"`
+}
+
+type InstanceType struct {
+	Database *Database `json:"database"`
+	Language *Language `json:"language"`
+}
+
+type CreateInstanceRequest struct {
+	Location string        `json:"location"`
+	Type     *InstanceType `json:"type"`
+	Name     string        `json:"name"`
+	Size     string        `json:"size"`
+}
+
+type ErrorResponse struct {
+	Cause   string `json:"cause,omitempty"`
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+	Object  string `json:"object,omitempty"`
+}


### PR DESCRIPTION
This PR adds a basic support for the Simple Hosting product (https://www.gandi.net/en/simple-hosting).
Currently, the GET, LIST, CREATE and DELETE operations on Simple Hosting instances are implemented and exposed via the CLI tool:
```
./gandi simple-hosting instance --help
Usage: gandi simple-hosting instance <command>

Simple Hosting commands

Flags:
      --help                 Show context-sensitive help.
      --version              Print version information and quit
  -d, --debug                Enable debug logging
      --dry-run              Enable dry run mode
      --api-key=STRING       The Gandi LiveDNS API key (may be stored in the GANDI_KEY environment variable)
  -i, --sharing-id=STRING    The Gandi LiveDNS sharingID (may be stored in the GANDI_SHARING_ID environment variable)

Commands:
  simple-hosting instance list
    List Simple Hosting instances

  simple-hosting instance delete <instance-id>
    Delete a Simple Hosting instance

  simple-hosting instance create <name> <location> <database> <language>
    Create a Simple Hosting instance
```

The main objective is to use these functions from the Terraform provider.

Also, I started to add some tests thanks the `gock` library which allows to nicely mock a webserver.