### PR TITLE
Add Simple Hosting Vhost LIST/CREATE/DELETE

### DIFF
--- a/cmd/simplehosting.go
+++ b/cmd/simplehosting.go
@@ -4,12 +4,19 @@ import "github.com/go-gandi/go-gandi/simplehosting"
 
 type simpleHostingCmd struct {
 	Instance instanceCmd `kong:"cmd,help='Simple Hosting instance commands'"`
+	Vhost    vhostCmd    `kong:"cmd,help='Simple Hosting vhost commands'"`
 }
 
 type instanceCmd struct {
 	List   instanceListCmd   `kong:"cmd,help='List Simple Hosting instances'"`
 	Delete instanceDeleteCmd `kong:"cmd,help='Delete a Simple Hosting instance'"`
 	Create instanceCreateCmd `kong:"cmd,help='Create a Simple Hosting instance'"`
+}
+
+type vhostCmd struct {
+	List   vhostListCmd   `kong:"cmd,help='List Simple Hosting vhosts'"`
+	Create vhostCreateCmd `kong:"cmd,help='Create a Simple Hosting vhost'"`
+	Delete vhostDeleteCmd `kong:"cmd,help='Delete a Simple Hosting vhost'"`
 }
 
 type instanceListCmd struct{}
@@ -48,4 +55,38 @@ func (cmd *instanceCreateCmd) Run(g *globals) error {
 				},
 			},
 		}))
+}
+
+type vhostListCmd struct {
+	InstanceId string `kong:"arg,help='The ID of a Simple Hosting instance'"`
+}
+type vhostCreateCmd struct {
+	InstanceId string `kong:"arg,help='The ID of a Simple Hosting instance'"`
+	FQDN       string `kong:"arg,help='The Vhost FQDN'"`
+}
+type vhostDeleteCmd struct {
+	InstanceId string `kong:"arg,help='The ID of a Simple Hosting instance'"`
+	FQDN       string `kong:"arg,help='The Vhost FQDN'"`
+}
+
+func (cmd *vhostListCmd) Run(g *globals) error {
+	s := g.simpleHostingHandle
+	return jsonPrint(s.ListVhosts(cmd.InstanceId))
+}
+
+func (cmd *vhostCreateCmd) Run(g *globals) error {
+	s := g.simpleHostingHandle
+	return jsonPrint(s.CreateVhost(
+		cmd.InstanceId,
+		simplehosting.CreateVhostRequest{
+			FQDN: cmd.FQDN,
+		}))
+}
+
+func (cmd *vhostDeleteCmd) Run(g *globals) error {
+	s := g.simpleHostingHandle
+	return jsonPrint(s.DeleteVhost(
+		cmd.InstanceId,
+		cmd.FQDN,
+	))
 }

--- a/simplehosting/simplehosting.go
+++ b/simplehosting/simplehosting.go
@@ -48,3 +48,24 @@ func (g *SimpleHosting) DeleteInstance(instanceId string) (response ErrorRespons
 	_, err = g.client.Delete("instances/"+instanceId, nil, &response)
 	return
 }
+
+// ListVhosts lists vhosts of a Simple Hosting instance
+func (g *SimpleHosting) ListVhosts(instanceId string) (response []Vhost, err error) {
+	_, err = g.client.Get("instances/"+instanceId+"/vhosts", nil, &response)
+	return
+}
+
+// ListVhosts creates a vhost for a Simple Hosting instance
+func (g *SimpleHosting) CreateVhost(instanceId string, req CreateVhostRequest) (response Vhost, err error) {
+	_, err = g.client.Post("instances/"+instanceId+"/vhosts", req, &response)
+	if err != nil {
+		return Vhost{}, err
+	}
+	return
+}
+
+// ListVhosts deletes vhosts of a Simple Hosting instance
+func (g *SimpleHosting) DeleteVhost(instanceId string, fqdn string) (response ErrorResponse, err error) {
+	_, err = g.client.Delete("instances/"+instanceId+"/vhosts/"+fqdn, nil, &response)
+	return
+}

--- a/simplehosting/types.go
+++ b/simplehosting/types.go
@@ -59,3 +59,20 @@ type ErrorResponse struct {
 	Message string `json:"message,omitempty"`
 	Object  string `json:"object,omitempty"`
 }
+
+type LinkedDNSZone struct {
+	AllowAlteration   bool   `json:"allow_alteration"`
+	LastCheckedStatus string `json:"last_checked_status"`
+}
+
+type Vhost struct {
+	CreatedAt     string         `json:"created_at"`
+	FQDN          string         `json:"fqdn"`
+	IsATestVhost  bool           `json:"is_a_test_vhost"`
+	LinkedDNSZone *LinkedDNSZone `json:"linked_dns_zone"`
+	Status        string         `json:"status"`
+}
+
+type CreateVhostRequest struct {
+	FQDN string `json:"fqdn"`
+}


### PR DESCRIPTION
A Vhost can be added to a simple hosting instance, such as decribed in this API https://api.gandi.net/docs/simplehosting/.