### PR TITLE
Add --url global cmd argument to use another API URL

### DIFF
--- a/cmd/gandi.go
+++ b/cmd/gandi.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alecthomas/kong"
 
 	"github.com/go-gandi/go-gandi"
+	"github.com/go-gandi/go-gandi/config"
 	"github.com/go-gandi/go-gandi/domain"
 	"github.com/go-gandi/go-gandi/livedns"
 	"github.com/go-gandi/go-gandi/simplehosting"
@@ -49,7 +50,7 @@ func main() {
 		},
 	}
 	ctx := kong.Parse(&c)
-	g := gandi.Config{
+	g := config.Config{
 		SharingID: c.SharingID,
 		Debug:     c.Debug,
 		DryRun:    c.DryRun,

--- a/cmd/gandi.go
+++ b/cmd/gandi.go
@@ -21,6 +21,7 @@ type cli struct {
 	Debug         bool             `kong:"short='d',help='Enable debug logging'"`
 	DryRun        bool             `kong:"help='Enable dry run mode'"`
 	APIKey        string           `kong:"env='GANDI_KEY',help='The Gandi LiveDNS API key (may be stored in the GANDI_KEY environment variable)'"`
+	APIURL        string           `kong:"help='The Gandi API URL',name='api-url',default='https://api.gandi.net'"`
 	SharingID     string           `kong:"short='i',env='GANDI_SHARING_ID',help='The Gandi LiveDNS sharingID (may be stored in the GANDI_SHARING_ID environment variable)'"`
 }
 
@@ -54,6 +55,7 @@ func main() {
 		SharingID: c.SharingID,
 		Debug:     c.Debug,
 		DryRun:    c.DryRun,
+		APIURL:    c.APIURL,
 	}
 	c.globals.domainHandle = gandi.NewDomainClient(c.APIKey, g)
 	c.globals.liveDNSHandle = gandi.NewLiveDNSClient(c.APIKey, g)

--- a/cmd/gandi.go
+++ b/cmd/gandi.go
@@ -52,14 +52,15 @@ func main() {
 	}
 	ctx := kong.Parse(&c)
 	g := config.Config{
+		APIKey:    c.APIKey,
 		SharingID: c.SharingID,
 		Debug:     c.Debug,
 		DryRun:    c.DryRun,
 		APIURL:    c.APIURL,
 	}
-	c.globals.domainHandle = gandi.NewDomainClient(c.APIKey, g)
-	c.globals.liveDNSHandle = gandi.NewLiveDNSClient(c.APIKey, g)
-	c.globals.simpleHostingHandle = gandi.NewSimpleHostingClient(c.APIKey, g)
+	c.globals.domainHandle = gandi.NewDomainClient(g)
+	c.globals.liveDNSHandle = gandi.NewLiveDNSClient(g)
+	c.globals.simpleHostingHandle = gandi.NewSimpleHostingClient(g)
 	err := ctx.Run(&c.globals)
 	ctx.FatalIfErrorf(err)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,11 @@
+package config
+
+// Config manages common config for all Gandi API types
+type Config struct {
+	// SharingID is the Organization ID, available from the Organization API
+	SharingID string
+	// Debug enables verbose debugging of HTTP calls
+	Debug bool
+	// DryRun prevents the API from making changes. Only certain API calls support it.
+	DryRun bool
+}

--- a/config/config.go
+++ b/config/config.go
@@ -8,4 +8,14 @@ type Config struct {
 	Debug bool
 	// DryRun prevents the API from making changes. Only certain API calls support it.
 	DryRun bool
+	// APIURL is the Gandi API URL. By default, it fallbacks to
+	// https://api.gandi.net.
+	APIURL string
 }
+
+const (
+	// APIURL is the default Config.APIURL value
+	APIURL = "https://api.gandi.net"
+	// SandboxAPIURL is the URL of the Gandi Sandbox API
+	SandboxAPIURL = "https://api.sandbox.gandi.net"
+)

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,8 @@ package config
 
 // Config manages common config for all Gandi API types
 type Config struct {
+	// APIKey is available from https://account.gandi.net/en/
+	APIKey string
 	// SharingID is the Organization ID, available from the Organization API
 	SharingID string
 	// Debug enables verbose debugging of HTTP calls

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1,12 +1,13 @@
 package domain
 
 import (
+	"github.com/go-gandi/go-gandi/config"
 	"github.com/go-gandi/go-gandi/internal/client"
 )
 
 // New returns an instance of the Domain API client
-func New(apikey string, sharingid string, debug bool, dryRun bool) *Domain {
-	client := client.New(apikey, sharingid, debug, dryRun)
+func New(apikey string, config config.Config) *Domain {
+	client := client.New(apikey, config.SharingID, config.Debug, config.DryRun)
 	client.SetEndpoint("domain/")
 	return &Domain{client: *client}
 }

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -6,8 +6,8 @@ import (
 )
 
 // New returns an instance of the Domain API client
-func New(apikey string, config config.Config) *Domain {
-	client := client.New(apikey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
+func New(config config.Config) *Domain {
+	client := client.New(config.APIKey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
 	client.SetEndpoint("domain/")
 	return &Domain{client: *client}
 }

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -7,7 +7,7 @@ import (
 
 // New returns an instance of the Domain API client
 func New(apikey string, config config.Config) *Domain {
-	client := client.New(apikey, config.SharingID, config.Debug, config.DryRun)
+	client := client.New(apikey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
 	client.SetEndpoint("domain/")
 	return &Domain{client: *client}
 }

--- a/email/email.go
+++ b/email/email.go
@@ -7,7 +7,7 @@ import (
 
 // New returns an instance of the Email API client
 func New(apikey string, config config.Config) *Email {
-	client := client.New(apikey, config.SharingID, config.Debug, config.DryRun)
+	client := client.New(apikey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
 	client.SetEndpoint("email/")
 	return &Email{client: *client}
 }

--- a/email/email.go
+++ b/email/email.go
@@ -6,8 +6,8 @@ import (
 )
 
 // New returns an instance of the Email API client
-func New(apikey string, config config.Config) *Email {
-	client := client.New(apikey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
+func New(config config.Config) *Email {
+	client := client.New(config.APIKey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
 	client.SetEndpoint("email/")
 	return &Email{client: *client}
 }

--- a/email/email.go
+++ b/email/email.go
@@ -1,10 +1,13 @@
 package email
 
-import "github.com/go-gandi/go-gandi/internal/client"
+import (
+	"github.com/go-gandi/go-gandi/config"
+	"github.com/go-gandi/go-gandi/internal/client"
+)
 
 // New returns an instance of the Email API client
-func New(apikey string, sharingid string, debug bool, dryRun bool) *Email {
-	client := client.New(apikey, sharingid, debug, dryRun)
+func New(apikey string, config config.Config) *Email {
+	client := client.New(apikey, config.SharingID, config.Debug, config.DryRun)
 	client.SetEndpoint("email/")
 	return &Email{client: *client}
 }

--- a/gandi.go
+++ b/gandi.go
@@ -10,24 +10,24 @@ import (
 
 // NewDomainClient returns a client to the Gandi Domains API
 // It expects an API key, available from https://account.gandi.net/en/
-func NewDomainClient(apikey string, config config.Config) *domain.Domain {
-	return domain.New(apikey, config)
+func NewDomainClient(config config.Config) *domain.Domain {
+	return domain.New(config)
 }
 
 // NewEmailClient returns a client to the Gandi Email API
 // It expects an API key, available from https://account.gandi.net/en/
-func NewEmailClient(apikey string, config config.Config) *email.Email {
-	return email.New(apikey, config)
+func NewEmailClient(config config.Config) *email.Email {
+	return email.New(config)
 }
 
 // NewLiveDNSClient returns a client to the Gandi Domains API
 // It expects an API key, available from https://account.gandi.net/en/
-func NewLiveDNSClient(apikey string, config config.Config) *livedns.LiveDNS {
-	return livedns.New(apikey, config)
+func NewLiveDNSClient(config config.Config) *livedns.LiveDNS {
+	return livedns.New(config)
 }
 
 // NewSimpleHostingClient returns a client to the Gandi Simple Hosting API
 // It expects an API key, available from https://account.gandi.net/en/
-func NewSimpleHostingClient(apikey string, config config.Config) *simplehosting.SimpleHosting {
-	return simplehosting.New(apikey, config)
+func NewSimpleHostingClient(config config.Config) *simplehosting.SimpleHosting {
+	return simplehosting.New(config)
 }

--- a/gandi.go
+++ b/gandi.go
@@ -1,42 +1,33 @@
 package gandi
 
 import (
+	"github.com/go-gandi/go-gandi/config"
 	"github.com/go-gandi/go-gandi/domain"
 	"github.com/go-gandi/go-gandi/email"
 	"github.com/go-gandi/go-gandi/livedns"
 	"github.com/go-gandi/go-gandi/simplehosting"
 )
 
-// Config manages common config for all Gandi API types
-type Config struct {
-	// SharingID is the Organization ID, available from the Organization API
-	SharingID string
-	// Debug enables verbose debugging of HTTP calls
-	Debug bool
-	// DryRun prevents the API from making changes. Only certain API calls support it.
-	DryRun bool
-}
-
 // NewDomainClient returns a client to the Gandi Domains API
 // It expects an API key, available from https://account.gandi.net/en/
-func NewDomainClient(apikey string, config Config) *domain.Domain {
-	return domain.New(apikey, config.SharingID, config.Debug, config.DryRun)
+func NewDomainClient(apikey string, config config.Config) *domain.Domain {
+	return domain.New(apikey, config)
 }
 
 // NewEmailClient returns a client to the Gandi Email API
 // It expects an API key, available from https://account.gandi.net/en/
-func NewEmailClient(apikey string, config Config) *email.Email {
-	return email.New(apikey, config.SharingID, config.Debug, config.DryRun)
+func NewEmailClient(apikey string, config config.Config) *email.Email {
+	return email.New(apikey, config)
 }
 
 // NewLiveDNSClient returns a client to the Gandi Domains API
 // It expects an API key, available from https://account.gandi.net/en/
-func NewLiveDNSClient(apikey string, config Config) *livedns.LiveDNS {
-	return livedns.New(apikey, config.SharingID, config.Debug, config.DryRun)
+func NewLiveDNSClient(apikey string, config config.Config) *livedns.LiveDNS {
+	return livedns.New(apikey, config)
 }
 
 // NewSimpleHostingClient returns a client to the Gandi Simple Hosting API
 // It expects an API key, available from https://account.gandi.net/en/
-func NewSimpleHostingClient(apikey string, config Config) *simplehosting.SimpleHosting {
-	return simplehosting.New(apikey, config.SharingID, config.Debug, config.DryRun)
+func NewSimpleHostingClient(apikey string, config config.Config) *simplehosting.SimpleHosting {
+	return simplehosting.New(apikey, config)
 }

--- a/internal/client/gandi.go
+++ b/internal/client/gandi.go
@@ -9,12 +9,9 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/go-gandi/go-gandi/config"
 	"github.com/go-gandi/go-gandi/types"
 	"moul.io/http2curl"
-)
-
-const (
-	gandiEndpoint = "https://api.gandi.net/v5/"
 )
 
 // Gandi is the handle used to interact with the Gandi API
@@ -27,13 +24,17 @@ type Gandi struct {
 }
 
 // New instantiates a new Gandi client
-func New(apikey string, sharingID string, debug bool, dryRun bool) *Gandi {
-	return &Gandi{apikey: apikey, endpoint: gandiEndpoint, sharingID: sharingID, debug: debug, dryRun: dryRun}
+func New(apikey string, apiurl string, sharingID string, debug bool, dryRun bool) *Gandi {
+	if apiurl == "" {
+		apiurl = config.APIURL
+	}
+	endpoint := apiurl + "/v5/"
+	return &Gandi{apikey: apikey, endpoint: endpoint, sharingID: sharingID, debug: debug, dryRun: dryRun}
 }
 
 // SetEndpoint sets the URL to the endpoint. It takes a string defining the subpath under https://api.gandi.net/v5/
 func (g *Gandi) SetEndpoint(endpoint string) {
-	g.endpoint = gandiEndpoint + endpoint
+	g.endpoint = g.endpoint + endpoint
 }
 
 // GetEndpoint gets the URL of the endpoint.

--- a/livedns/livedns.go
+++ b/livedns/livedns.go
@@ -7,7 +7,7 @@ import (
 
 // New returns an instance of the LiveDNS API client
 func New(apikey string, config config.Config) *LiveDNS {
-	client := client.New(apikey, config.SharingID, config.Debug, config.DryRun)
+	client := client.New(apikey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
 	client.SetEndpoint("livedns/")
 	return &LiveDNS{client: *client}
 }

--- a/livedns/livedns.go
+++ b/livedns/livedns.go
@@ -1,12 +1,13 @@
 package livedns
 
 import (
+	"github.com/go-gandi/go-gandi/config"
 	"github.com/go-gandi/go-gandi/internal/client"
 )
 
 // New returns an instance of the LiveDNS API client
-func New(apikey string, sharingid string, debug bool, dryRun bool) *LiveDNS {
-	client := client.New(apikey, sharingid, debug, dryRun)
+func New(apikey string, config config.Config) *LiveDNS {
+	client := client.New(apikey, config.SharingID, config.Debug, config.DryRun)
 	client.SetEndpoint("livedns/")
 	return &LiveDNS{client: *client}
 }

--- a/livedns/livedns.go
+++ b/livedns/livedns.go
@@ -6,8 +6,8 @@ import (
 )
 
 // New returns an instance of the LiveDNS API client
-func New(apikey string, config config.Config) *LiveDNS {
-	client := client.New(apikey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
+func New(config config.Config) *LiveDNS {
+	client := client.New(config.APIKey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
 	client.SetEndpoint("livedns/")
 	return &LiveDNS{client: *client}
 }

--- a/simplehosting/instance_test.go
+++ b/simplehosting/instance_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/go-gandi/go-gandi/simplehosting"
+	"github.com/go-gandi/go-gandi/config"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -15,7 +16,7 @@ func TestDeleteInstance(t *testing.T) {
 		Delete("/instances/" + instanceId).
 		Reply(204)
 
-	simpleHosting := simplehosting.New("", "", true, false)
+	simpleHosting := simplehosting.New("", config.Config{})
 	response, err := simpleHosting.DeleteInstance(instanceId)
 	if err != nil {
 		t.Fatal(err)
@@ -57,7 +58,7 @@ func TestCreateInstance(t *testing.T) {
 			"message": "Instance is being created",
 		})
 
-	simpleHosting := simplehosting.New("", "", true, false)
+	simpleHosting := simplehosting.New("", config.Config{})
 	instanceId, err := simpleHosting.CreateInstance(
 		simplehosting.CreateInstanceRequest{
 			Name:     instanceName,

--- a/simplehosting/instance_test.go
+++ b/simplehosting/instance_test.go
@@ -3,8 +3,8 @@ package simplehosting_test
 import (
 	"testing"
 
-	"github.com/go-gandi/go-gandi/simplehosting"
 	"github.com/go-gandi/go-gandi/config"
+	"github.com/go-gandi/go-gandi/simplehosting"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -16,7 +16,7 @@ func TestDeleteInstance(t *testing.T) {
 		Delete("/instances/" + instanceId).
 		Reply(204)
 
-	simpleHosting := simplehosting.New("", config.Config{})
+	simpleHosting := simplehosting.New(config.Config{})
 	response, err := simpleHosting.DeleteInstance(instanceId)
 	if err != nil {
 		t.Fatal(err)
@@ -58,7 +58,7 @@ func TestCreateInstance(t *testing.T) {
 			"message": "Instance is being created",
 		})
 
-	simpleHosting := simplehosting.New("", config.Config{})
+	simpleHosting := simplehosting.New(config.Config{})
 	instanceId, err := simpleHosting.CreateInstance(
 		simplehosting.CreateInstanceRequest{
 			Name:     instanceName,

--- a/simplehosting/simplehosting.go
+++ b/simplehosting/simplehosting.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-gandi/go-gandi/config"
 	"github.com/go-gandi/go-gandi/internal/client"
 )
 
 // New returns an instance of the Simple Hosting API client
-func New(apikey string, sharingid string, debug bool, dryRun bool) *SimpleHosting {
-	client := client.New(apikey, sharingid, debug, dryRun)
+func New(apikey string, config config.Config) *SimpleHosting {
+	client := client.New(apikey, config.SharingID, config.Debug, config.DryRun)
 	client.SetEndpoint("simplehosting/")
 	return &SimpleHosting{client: *client}
 }

--- a/simplehosting/simplehosting.go
+++ b/simplehosting/simplehosting.go
@@ -10,7 +10,7 @@ import (
 
 // New returns an instance of the Simple Hosting API client
 func New(apikey string, config config.Config) *SimpleHosting {
-	client := client.New(apikey, config.SharingID, config.Debug, config.DryRun)
+	client := client.New(apikey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
 	client.SetEndpoint("simplehosting/")
 	return &SimpleHosting{client: *client}
 }

--- a/simplehosting/simplehosting.go
+++ b/simplehosting/simplehosting.go
@@ -9,8 +9,8 @@ import (
 )
 
 // New returns an instance of the Simple Hosting API client
-func New(apikey string, config config.Config) *SimpleHosting {
-	client := client.New(apikey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
+func New(config config.Config) *SimpleHosting {
+	client := client.New(config.APIKey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
 	client.SetEndpoint("simplehosting/")
 	return &SimpleHosting{client: *client}
 }


### PR DESCRIPTION
Because at Gandi, we have more plateforms than just the production
one, this patch facilitates the test of this library.

Note also, a public sandbox API is coming soon (this API could be used to test our API without creating any resources).

The CLI help now looks like:
```
./gandi --help
Usage: gandi <command>

Flags:
      --help                 Show context-sensitive help.
      --version              Print version information and quit
  -d, --debug                Enable debug logging
      --dry-run              Enable dry run mode
      --api-key=STRING       The Gandi LiveDNS API key (may be stored in the
                             GANDI_KEY environment variable)
      --url="https://api.gandi.net"
                             The Gandi API URL
  -i, --sharing-id=STRING    The Gandi LiveDNS sharingID (may be stored in the
                             GANDI_SHARING_ID environment variable)

```