### PR TITLE
Adds web redirection handling to API client.

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -92,7 +92,7 @@ func (g *Domain) ListWebRedirections(domain string) (webredirs []WebRedirection,
 	return
 }
 
-func (g *Domain) DeleteWebRedirection(domain string, keyid string) (err error) {
-	_, err = g.client.Delete("domains/"+domain+"/webredirs/"+keyid, nil, nil)
+func (g *Domain) DeleteWebRedirection(domain string, host string) (err error) {
+	_, err = g.client.Delete("domains/"+domain+"/webredirs/"+host, nil, nil)
 	return
 }

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -81,3 +81,18 @@ func (g *Domain) DeleteDNSSECKey(domain string, keyid string) (err error) {
 	_, err = g.client.Delete("domains/"+domain+"/dnskeys/"+keyid, nil, nil)
 	return
 }
+
+func (g *Domain) CreateWebRedirection(domain string, webredir WebRedirectionCreateRequest) (err error) {
+	_, err = g.client.Post("domains/"+domain+"/webredirs", webredir, nil)
+	return
+}
+
+func (g *Domain) ListWebRedirections(domain string) (webredirs []WebRedirection, err error) {
+	_, err = g.client.Get("domains/"+domain+"/webredirs", nil, &webredirs)
+	return
+}
+
+func (g *Domain) DeleteWebRedirection(domain string, keyid string) (err error) {
+	_, err = g.client.Delete("domains/"+domain+"/webredirs/"+keyid, nil, nil)
+	return
+}

--- a/domain/types.go
+++ b/domain/types.go
@@ -163,3 +163,24 @@ type DNSSECKeyCreateRequest struct {
 	Type      string `json:"type"`
 	PublicKey string `json:"public_key"`
 }
+
+// WebRedirection represents a WebRedirections associated with a domain
+type WebRedirection struct {
+	Host              string     `json:"host"`
+	Type              string     `json:"type"`
+	URL               string     `json:"url"`
+	CertificateStatus string     `json:"cert_status,omitempty"`
+	CertificateUUID   string     `json:"cert_uuid,omitempty"`
+	CreatedAt         *time.Time `json:"created_at,omitempty"`
+	Protocol          string     `json:"protocol,omitempty"`
+	UpdatedAt         *time.Time `json:"updated_at,omitempty"`
+}
+
+// WebRedirectionCreateRequest represents a request to create a WebRedirections for a domain
+type WebRedirectionCreateRequest struct {
+	Host     string `json:"host"`
+	Override bool   `json:"override"`
+	Protocol string `json:"protocol"`
+	Type     string `json:"type"`
+	URL      string `json:"url"`
+}


### PR DESCRIPTION
Based on the API contract for web redirections provided [here](https://api.gandi.net/docs/domains/#patch-v5-domain-domains-domain-webredirs-host).  This will be accompanied with a dependent PR within the https://github.com/go-gandi/terraform-provider-gandi repo.