### PR TITLE
Adding Glue Record requests to the domain package.

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -82,6 +82,26 @@ func (g *Domain) DeleteDNSSECKey(domain string, keyid string) (err error) {
 	return
 }
 
+func (g *Domain) CreateGlueRecord(domain string, gluerecord GlueRecordCreateRequest) (err error) {
+	_, err = g.client.Post("domains/"+domain+"/hosts", gluerecord, nil)
+	return
+}
+
+func (g *Domain) ListGlueRecords(domain string) (gluerecords []GlueRecord, err error) {
+	_, err = g.client.Get("domains/"+domain+"/hosts", nil, &gluerecords)
+	return
+}
+
+func (g *Domain) UpdateGlueRecord(domain string, name string, ips []string) (err error) {
+	_, err = g.client.Put("domains/"+domain+"/hosts/"+name, GlueRecordUpdateRequest{ips}, nil)
+	return
+}
+
+func (g *Domain) DeleteGlueRecord(domain string, name string) (err error) {
+	_, err = g.client.Delete("domains/"+domain+"/hosts/"+name, nil, nil)
+	return
+}
+
 func (g *Domain) CreateWebRedirection(domain string, webredir WebRedirectionCreateRequest) (err error) {
 	_, err = g.client.Post("domains/"+domain+"/webredirs", webredir, nil)
 	return

--- a/domain/types.go
+++ b/domain/types.go
@@ -164,6 +164,26 @@ type DNSSECKeyCreateRequest struct {
 	PublicKey string `json:"public_key"`
 }
 
+// GlueRecord represents the association of a hostname with an IP address at the registry.
+type GlueRecord struct {
+	Name        string   `json:"name"`
+	IPs         []string `json:"ips"`
+	FQDN        string   `json:"fqdn"`
+	Href        string   `json:"href"`
+	FQDNUnicode string   `json:"fqdn_unicode"`
+}
+
+// GlueRecordCreateRequest represents a request to create a GlueRecord for a domain
+type GlueRecordCreateRequest struct {
+	Name string   `json:"name"`
+	IPs  []string `json:"ips"`
+}
+
+// GlueRecordUpdateRequest represents a request to update an existing GlueRecords IP addresses
+type GlueRecordUpdateRequest struct {
+	IPs []string `json:"ips"`
+}
+
 // WebRedirection represents a WebRedirections associated with a domain
 type WebRedirection struct {
 	Host              string     `json:"host"`


### PR DESCRIPTION
Based on the API contract information provided [here](https://api.gandi.net/docs/domains/#v5-domain-domains-domain-hosts), this adds the ability to manage Glue Records via the go client.  This will be accompanied with a dependent PR within the [terraform-provider repo.](https://github.com/go-gandi/terraform-provider-gandi)