### PR TITLE
Adding get glue record method to domain client.

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -93,6 +93,11 @@ func (g *Domain) ListGlueRecords(domain string) (gluerecords []GlueRecord, err e
 	return
 }
 
+func (g *Domain) GetGlueRecord(domain string, name string) (gluerecord GlueRecord, err error) {
+	_, err = g.client.Get("domains/"+domain+"/hosts/"+name, nil, &gluerecord)
+	return
+}
+
 func (g *Domain) UpdateGlueRecord(domain string, name string, ips []string) (err error) {
 	_, err = g.client.Put("domains/"+domain+"/hosts/"+name, GlueRecordUpdateRequest{ips}, nil)
 	return


### PR DESCRIPTION
This is a follow-up to the PR #44, based on discussion in https://github.com/go-gandi/terraform-provider-gandi/pull/73.

 