### PR TITLE
Support pagination

### DIFF
--- a/certificate/certificate.go
+++ b/certificate/certificate.go
@@ -1,6 +1,8 @@
 package certificate
 
 import (
+	"encoding/json"
+
 	"github.com/go-gandi/go-gandi/config"
 	"github.com/go-gandi/go-gandi/internal/client"
 )
@@ -14,8 +16,19 @@ func New(config config.Config) *Certificate {
 
 // ListCertificates requests the list of issued certificates
 func (g *Certificate) ListCertificates() (certificates []CertificateType, err error) {
-	_, err = g.client.Get("issued-certs", nil, &certificates)
-	return
+	_, elements, err := g.client.GetCollection("issued-certs", nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, element := range elements {
+		var certificate CertificateType
+		err := json.Unmarshal(element, &certificate)
+		if err != nil {
+			return nil, err
+		}
+		certificates = append(certificates, certificate)
+	}
+	return certificates, nil
 }
 
 // GetCertificate request details of an issued certificates
@@ -38,6 +51,17 @@ func (g *Certificate) DeleteCertificate(certificateId string) (response ErrorRes
 
 // ListPackages lists certificate package types
 func (g *Certificate) ListPackages() (packages []Package, err error) {
-	_, err = g.client.Get("packages", nil, &packages)
-	return
+	_, elements, err := g.client.GetCollection("packages", nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, element := range elements {
+		var package_ Package
+		err := json.Unmarshal(element, &package_)
+		if err != nil {
+			return nil, err
+		}
+		packages = append(packages, package_)
+	}
+	return packages, nil
 }

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1,6 +1,8 @@
 package domain
 
 import (
+	"encoding/json"
+
 	"github.com/go-gandi/go-gandi/config"
 	"github.com/go-gandi/go-gandi/internal/client"
 )
@@ -21,8 +23,19 @@ func NewFromClient(g client.Gandi) *Domain {
 // ListDomains requests the set of Domains
 // It returns a slice of domains and any error encountered
 func (g *Domain) ListDomains() (domains []ListResponse, err error) {
-	_, err = g.client.Get("domains", nil, &domains)
-	return
+	_, elements, err := g.client.GetCollection("domains", nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, element := range elements {
+		var key ListResponse
+		err := json.Unmarshal(element, &key)
+		if err != nil {
+			return nil, err
+		}
+		domains = append(domains, key)
+	}
+	return domains, nil
 }
 
 // GetDomain requests a single Domain
@@ -69,8 +82,19 @@ func (g *Domain) SetAutoRenew(domain string, autorenew bool) (err error) {
 }
 
 func (g *Domain) ListDNSSECKeys(domain string) (keys []DNSSECKey, err error) {
-	_, err = g.client.Get("domains/"+domain+"/dnskeys", nil, &keys)
-	return
+	_, elements, err := g.client.GetCollection("domains/"+domain+"/dnskeys", nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, element := range elements {
+		var key DNSSECKey
+		err := json.Unmarshal(element, &key)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
 }
 
 func (g *Domain) CreateDNSSECKey(domain string, key DNSSECKeyCreateRequest) (err error) {
@@ -89,8 +113,19 @@ func (g *Domain) CreateGlueRecord(domain string, gluerecord GlueRecordCreateRequ
 }
 
 func (g *Domain) ListGlueRecords(domain string) (gluerecords []GlueRecord, err error) {
-	_, err = g.client.Get("domains/"+domain+"/hosts", nil, &gluerecords)
-	return
+	_, elements, err := g.client.GetCollection("domains/"+domain+"/hosts", nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, element := range elements {
+		var gluerecord GlueRecord
+		err := json.Unmarshal(element, &gluerecord)
+		if err != nil {
+			return nil, err
+		}
+		gluerecords = append(gluerecords, gluerecord)
+	}
+	return gluerecords, nil
 }
 
 func (g *Domain) GetGlueRecord(domain string, name string) (gluerecord GlueRecord, err error) {
@@ -114,8 +149,19 @@ func (g *Domain) CreateWebRedirection(domain string, webredir WebRedirectionCrea
 }
 
 func (g *Domain) ListWebRedirections(domain string) (webredirs []WebRedirection, err error) {
-	_, err = g.client.Get("domains/"+domain+"/webredirs", nil, &webredirs)
-	return
+	_, elements, err := g.client.GetCollection("domains/"+domain+"/webredirs", nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, element := range elements {
+		var webredir WebRedirection
+		err := json.Unmarshal(element, &webredir)
+		if err != nil {
+			return nil, err
+		}
+		webredirs = append(webredirs, webredir)
+	}
+	return webredirs, nil
 }
 
 func (g *Domain) DeleteWebRedirection(domain string, host string) (err error) {

--- a/email/email.go
+++ b/email/email.go
@@ -1,6 +1,8 @@
 package email
 
 import (
+	"encoding/json"
+
 	"github.com/go-gandi/go-gandi/config"
 	"github.com/go-gandi/go-gandi/internal/client"
 )
@@ -20,8 +22,19 @@ func NewFromClient(g client.Gandi) *Email {
 
 // ListMailboxes list mailboxes attached to domain
 func (e *Email) ListMailboxes(domain string) (mailboxes []ListMailboxResponse, err error) {
-	_, err = e.client.Get("/mailboxes/"+domain, nil, &mailboxes)
-	return
+	_, elements, err := e.client.GetCollection("/mailboxes/"+domain, nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, element := range elements {
+		var mailbox ListMailboxResponse
+		err := json.Unmarshal(element, &mailbox)
+		if err != nil {
+			return nil, err
+		}
+		mailboxes = append(mailboxes, mailbox)
+	}
+	return mailboxes, nil
 }
 
 // GetMailbox returns all the parameters linked to a specific mailbox

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/alecthomas/kong v0.2.2
+	github.com/peterhellberg/link v1.1.0
 	gopkg.in/h2non/gock.v1 v1.1.2
 	moul.io/http2curl v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
+github.com/peterhellberg/link v1.1.0 h1:s2+RH8EGuI/mI4QwrWGSYQCRz7uNgip9BaM04HKu5kc=
+github.com/peterhellberg/link v1.1.0/go.mod h1:gtSlOT4jmkY8P47hbTc8PTgiDDWpdPbFYl75keYyBB8=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/client/gandi_test.go
+++ b/internal/client/gandi_test.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"gopkg.in/h2non/gock.v1"
+)
+
+type element struct {
+	Item string `json:"item"`
+}
+
+func TestAskGandiCollection(t *testing.T) {
+	defer gock.Off()
+	gock.New("https://api.gandi.net/v5/").
+		Get("/domain/domains").
+		Reply(200).
+		SetHeader("link", "<https://api.gandi.net/v5/domain/domains?page=2&sort_by=fqdn>; rel=\"next\", <https://api.gandi.net/v5/domain/domains?sort_by=fqdn&page=2>; rel=\"last\"").
+		JSON([]map[string]string{map[string]string{"item": "item1"}})
+
+	gock.New("https://api.gandi.net/v5/").
+		Get("/domain/domains").
+		MatchParam("page", "2").
+		MatchParam("sort_by", "fqdn").
+		Reply(200).
+		JSON([]map[string]string{map[string]string{"item": "item2"}})
+
+	client := New("", "https://api.gandi.net", "", false, false)
+	var elements []element
+	_, rawMessages, err := client.askGandiCollection("GET", "domain/domains", nil)
+	for _, rawMessage := range rawMessages {
+		var element element
+		err := json.Unmarshal(rawMessage, &element)
+		if err != nil {
+			t.Fatal(err)
+		}
+		elements = append(elements, element)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []element{
+		element{
+			Item: "item1",
+		},
+		element{
+			Item: "item2",
+		},
+	}
+	if !reflect.DeepEqual(elements, expected) {
+		t.Fatalf("Expected elements are '%#v' (actual %#v)", expected, elements)
+	}
+
+}
+
+func TestAskGandiCollectionEmpty(t *testing.T) {
+	defer gock.Off()
+	gock.New("https://api.gandi.net/v5/").
+		Get("/domain/domains").
+		Reply(200).
+		JSON([]map[string]string{})
+	client := New("", "https://api.gandi.net", "", false, false)
+	_, rawMessages, err := client.askGandiCollection("GET", "domain/domains", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rawMessages) != 0 {
+		t.Fatalf("Length of elements slice should be 0 (instead of %d)", len(rawMessages))
+	}
+
+}

--- a/livedns/domain.go
+++ b/livedns/domain.go
@@ -1,13 +1,26 @@
 package livedns
 
 import (
+	"encoding/json"
+
 	"github.com/go-gandi/go-gandi/types"
 )
 
 // ListDomains lists all domains
 func (g *LiveDNS) ListDomains() (domains []Domain, err error) {
-	_, err = g.client.Get("domains", nil, &domains)
-	return
+	_, elements, err := g.client.GetCollection("domains", nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, element := range elements {
+		var domain Domain
+		err := json.Unmarshal(element, &domain)
+		if err != nil {
+			return nil, err
+		}
+		domains = append(domains, domain)
+	}
+	return domains, nil
 }
 
 // CreateDomain adds a domain to a zone

--- a/livedns/snapshots.go
+++ b/livedns/snapshots.go
@@ -1,13 +1,26 @@
 package livedns
 
 import (
+	"encoding/json"
+
 	"github.com/go-gandi/go-gandi/types"
 )
 
 // ListSnapshots lists all snapshots for a domain
 func (g *LiveDNS) ListSnapshots(fqdn string) (snapshots []Snapshot, err error) {
-	_, err = g.client.Get("domains/"+fqdn+"/snapshots", nil, &snapshots)
-	return
+	_, elements, err := g.client.GetCollection("domains/"+fqdn+"/snapshots", nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, element := range elements {
+		var snapshot Snapshot
+		err := json.Unmarshal(element, &snapshot)
+		if err != nil {
+			return nil, err
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+	return snapshots, nil
 }
 
 // CreateSnapshot creates a snapshot for a domain

--- a/simplehosting/simplehosting.go
+++ b/simplehosting/simplehosting.go
@@ -1,6 +1,7 @@
 package simplehosting
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -16,9 +17,20 @@ func New(config config.Config) *SimpleHosting {
 }
 
 // ListInstances requests the list of SimpleHosting instances
-func (g *SimpleHosting) ListInstances() (simplehostings []Instance, err error) {
-	_, err = g.client.Get("instances", nil, &simplehostings)
-	return
+func (g *SimpleHosting) ListInstances() (instances []Instance, err error) {
+	_, elements, err := g.client.GetCollection("instances", nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, element := range elements {
+		var instance Instance
+		err := json.Unmarshal(element, &instance)
+		if err != nil {
+			return nil, err
+		}
+		instances = append(instances, instance)
+	}
+	return instances, nil
 }
 
 // GetInstance requests a single Instance
@@ -57,9 +69,20 @@ func (g *SimpleHosting) GetVhost(instanceId string, fqdn string) (response Vhost
 }
 
 // ListVhosts lists vhosts of a Simple Hosting instance
-func (g *SimpleHosting) ListVhosts(instanceId string) (response []Vhost, err error) {
-	_, err = g.client.Get("instances/"+instanceId+"/vhosts", nil, &response)
-	return
+func (g *SimpleHosting) ListVhosts(instanceId string) (vhosts []Vhost, err error) {
+	_, elements, err := g.client.GetCollection("instances/"+instanceId+"/vhosts", nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, element := range elements {
+		var vhost Vhost
+		err := json.Unmarshal(element, &vhost)
+		if err != nil {
+			return nil, err
+		}
+		vhosts = append(vhosts, vhost)
+	}
+	return vhosts, nil
 }
 
 // ListVhosts creates a vhost for a Simple Hosting instance


### PR DESCRIPTION
The method `GetCollection` has been added to retrieve a list of paginated resources.

The implementation is not really clean but it avoids to much refactoring. It would actually be better to use a channel or an iterator but this would need more work and discussions.

The main drawback is that I had to
1. `Unmarshal` each response to slices, 
2. concat these slices, 
3. `Marshal` the resulting slices and
4.  `Unmarshal` this slice with the correct type.

This is because it's not possible to deconstruct the slice type.

Regarding performances, i don't think storing all resources in memory is a real issue (with an iterator/channel, they would be fetch on demand).

The goal of this patch is to fix the issue https://github.com/go-gandi/go-gandi/issues/19 in order to make a release. I think we could improve this implementation in future releases.

Also, i added pagination tests :tada:

This is a draft PR because I still have to use `GetCollection` on all paginated methods but i would prefer to have feedbacks before spending more time on this.