### PR TITLE
livedns: return public key and tag

### DIFF
--- a/livedns/types.go
+++ b/livedns/types.go
@@ -57,6 +57,8 @@ type SigningKey struct {
 	FQDN          string `json:"fqdn,omitempty"`
 	Flags         int    `json:"flags,omitempty"`
 	DS            string `json:"ds,omitempty"`
+	PublicKey     string `json:"public_key,omitempty"`
+	Tag           int    `json:"tag,omitempty"`
 	KeyHref       string `json:"key_href,omitempty"`
 }
 


### PR DESCRIPTION
The API provides them when querying a specific domain key. It does not
when querying all domain keys for a domain. We do not try to handle
this in any way.

Fixes #55 