### PR TITLE
livedns: on key creation, return the UUID of the created key

### DIFF
--- a/livedns/keys_test.go
+++ b/livedns/keys_test.go
@@ -1,0 +1,38 @@
+package livedns_test
+
+import (
+	"testing"
+
+	"github.com/go-gandi/go-gandi/config"
+	"github.com/go-gandi/go-gandi/livedns"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestSignDomain(t *testing.T) {
+	defer gock.Off()
+	expectedUUID := "29f246af-fe71-4d73-8693-ac2d0e49b23b"
+
+	gock.Observe(gock.DumpRequest)
+	gock.New("https://api.gandi.net/v5/").
+		Post("livedns/domains/example.com/keys").
+		JSON(map[string]interface{}{
+			"flags": 257,
+		}).
+		Reply(201).
+		SetHeader(
+			"location",
+			"https://api.gandi.net/v5/livedns/domains/example.com/keys/"+expectedUUID).
+		JSON(map[string]string{
+			"message": "Domain Key Created",
+		})
+
+	liveDNS := livedns.New(config.Config{})
+	response, err := liveDNS.SignDomain("example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.UUID != expectedUUID {
+		t.Fatalf("UUID should be '%s' (while it is %s)",
+			expectedUUID, response.UUID)
+	}
+}

--- a/livedns/types.go
+++ b/livedns/types.go
@@ -52,7 +52,7 @@ type SigningKey struct {
 	Status        string `json:"status,omitempty"`
 	UUID          string `json:"id,omitempty"`
 	Algorithm     int    `json:"algorithm,omitempty"`
-	Deleted       *bool  `json:"deleted"`
+	Deleted       *bool  `json:"deleted,omitempty"`
 	AlgorithmName string `json:"algorithm_name,omitempty"`
 	FQDN          string `json:"fqdn,omitempty"`
 	Flags         int    `json:"flags,omitempty"`


### PR DESCRIPTION
The StandardResponse type has an UUID field, so we use it to store the
UUID. It would have been better to return the UUID directly as the
StandardResponse type is empty otherwise, but it would be an API
change. Maybe take a mental note for the next major version?