### PR TITLE
doAskGandi returns a RequestError on HTTP failure

### DIFF
--- a/internal/client/gandi.go
+++ b/internal/client/gandi.go
@@ -132,6 +132,9 @@ func (g *Gandi) GetBytes(path string, params interface{}) (http.Header, []byte, 
 	return g.doAskGandi(http.MethodGet, path, params, headers)
 }
 
+// doAskGandi performs a call to the API. If the HTTP status code of
+// the response is not success, the returned error is a RequestError
+// (which contains the HTTP StatusCode).
 func (g *Gandi) doAskGandi(method, path string, p interface{}, extraHeaders [][2]string) (http.Header, []byte, error) {
 	var (
 		err error
@@ -205,7 +208,10 @@ func (g *Gandi) doAskGandi(method, path string, p interface{}, extraHeaders [][2
 			err = fmt.Errorf(strings.Join(errors, ", "))
 		} else {
 			err = fmt.Errorf("%d", resp.StatusCode)
-
+		}
+		err = &types.RequestError{
+			Err:        err,
+			StatusCode: resp.StatusCode,
 		}
 	}
 	return resp.Header, body, err

--- a/types/types.go
+++ b/types/types.go
@@ -1,5 +1,9 @@
 package types
 
+import (
+	"fmt"
+)
+
 // StandardResponse is a standard response
 type StandardResponse struct {
 	Code    int             `json:"code,omitempty"`
@@ -16,4 +20,13 @@ type StandardError struct {
 	Location    string `json:"location"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
+}
+
+type RequestError struct {
+	Err        error
+	StatusCode int
+}
+
+func (e *RequestError) Error() string {
+	return fmt.Sprintf("StatusCode: %d ; Err: %s ", e.StatusCode, e.Err)
 }


### PR DESCRIPTION
This would allows us to catch 404 error (a non existing object) in the
Terraform provider (see
https://github.com/go-gandi/terraform-provider-gandi/issues/100) in
order to let Terraform recreate them.