### PR TITLE
domain: do not omit empty nameservers

### DIFF
--- a/domain/types.go
+++ b/domain/types.go
@@ -143,7 +143,7 @@ type Contacts struct {
 
 // Nameservers represents a list of nameservers
 type Nameservers struct {
-	Nameservers []string `json:"nameservers,omitempty"`
+	Nameservers []string `json:"nameservers"`
 }
 
 // DNSSECKey represents a DNSSEC key associated with a domain


### PR DESCRIPTION
The Nameservers struct is only used by the UpdateNameServers method
which makes a PUT to the nameservers API: the nameservers body
attribute is required.

This is to avoid this kind of issues:

    2022-04-05T10:15:52.821+0200 [INFO]  provider.terraform-provider-gandi: 2022/04/05 10:15:52 Request:  curl -X 'PUT' -d '{}' -H 'Authorization: Apikey X' -H 'Content-Type: application/json' 'https://api.gandi.net/v5/domain/domains/bla.fr/nameservers': timestamp=2022-04-05T10:15:52.821+0200
    2022-04-05T10:15:53.139+0200 [INFO]  provider.terraform-provider-gandi: 2022/04/05 10:15:53 Response : [400 Bad Request]
    2022-04-05T10:15:53.139+0200 [INFO]  provider.terraform-provider-gandi: 2022/04/05 10:15:53 Response body: {"status": "error", "errors": [{"location": "body", "name": "nameservers", "description": "Required"}]}: timestamp=2022-04-05T10:15:53.138+0200