### PR TITLE
Add timeout to requests

### DIFF
--- a/certificate/certificate.go
+++ b/certificate/certificate.go
@@ -9,7 +9,7 @@ import (
 
 // New returns an instance of the Certificate API client
 func New(config config.Config) *Certificate {
-	client := client.New(config.APIKey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
+	client := client.New(config.APIKey, config.APIURL, config.SharingID, config.Debug, config.DryRun, config.Timeout)
 	client.SetEndpoint("certificate/")
 	return &Certificate{client: *client}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 // Config manages common config for all Gandi API types
 type Config struct {
 	// APIKey is available from https://account.gandi.net/en/
@@ -13,6 +15,8 @@ type Config struct {
 	// APIURL is the Gandi API URL. By default, it fallbacks to
 	// https://api.gandi.net.
 	APIURL string
+	// Timeout is the timeout for requests against the Gandi API
+	Timeout time.Duration
 }
 
 const (
@@ -20,4 +24,6 @@ const (
 	APIURL = "https://api.gandi.net"
 	// SandboxAPIURL is the URL of the Gandi Sandbox API
 	SandboxAPIURL = "https://api.sandbox.gandi.net"
+	// Timeout is the default timeout of 5 seconds
+	Timeout = 5 * time.Second
 )

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -9,7 +9,7 @@ import (
 
 // New returns an instance of the Domain API client
 func New(config config.Config) *Domain {
-	client := client.New(config.APIKey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
+	client := client.New(config.APIKey, config.APIURL, config.SharingID, config.Debug, config.DryRun, config.Timeout)
 	client.SetEndpoint("domain/")
 	return &Domain{client: *client}
 }

--- a/email/email.go
+++ b/email/email.go
@@ -9,7 +9,7 @@ import (
 
 // New returns an instance of the Email API client
 func New(config config.Config) *Email {
-	client := client.New(config.APIKey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
+	client := client.New(config.APIKey, config.APIURL, config.SharingID, config.Debug, config.DryRun, config.Timeout)
 	client.SetEndpoint("email/")
 	return &Email{client: *client}
 }

--- a/internal/client/gandi_test.go
+++ b/internal/client/gandi_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/go-gandi/go-gandi/types"
 	"gopkg.in/h2non/gock.v1"
@@ -29,7 +30,7 @@ func TestAskGandiCollection(t *testing.T) {
 		Reply(200).
 		JSON([]map[string]string{map[string]string{"item": "item2"}})
 
-	client := New("", "https://api.gandi.net", "", false, false)
+	client := New("", "https://api.gandi.net", "", false, false, 1*time.Second)
 	var elements []element
 	_, rawMessages, err := client.askGandiCollection("GET", "domain/domains", nil)
 	for _, rawMessage := range rawMessages {
@@ -63,7 +64,7 @@ func TestAskGandiCollectionEmpty(t *testing.T) {
 		Get("/domain/domains").
 		Reply(200).
 		JSON([]map[string]string{})
-	client := New("", "https://api.gandi.net", "", false, false)
+	client := New("", "https://api.gandi.net", "", false, false, 1*time.Second)
 	_, rawMessages, err := client.askGandiCollection("GET", "domain/domains", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -80,7 +81,7 @@ func TestRequestError(t *testing.T) {
 		Get("/domain/domains").
 		Reply(500).
 		JSON(types.StandardResponse{})
-	client := New("", "https://api.gandi.net", "", false, false)
+	client := New("", "https://api.gandi.net", "", false, false, 1*time.Second)
 	response := []map[string]string{}
 	_, err := client.Get("domain/domains", nil, &response)
 

--- a/livedns/livedns.go
+++ b/livedns/livedns.go
@@ -7,7 +7,7 @@ import (
 
 // New returns an instance of the LiveDNS API client
 func New(config config.Config) *LiveDNS {
-	client := client.New(config.APIKey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
+	client := client.New(config.APIKey, config.APIURL, config.SharingID, config.Debug, config.DryRun, config.Timeout)
 	client.SetEndpoint("livedns/")
 	return &LiveDNS{client: *client}
 }

--- a/simplehosting/simplehosting.go
+++ b/simplehosting/simplehosting.go
@@ -11,7 +11,7 @@ import (
 
 // New returns an instance of the Simple Hosting API client
 func New(config config.Config) *SimpleHosting {
-	client := client.New(config.APIKey, config.APIURL, config.SharingID, config.Debug, config.DryRun)
+	client := client.New(config.APIKey, config.APIURL, config.SharingID, config.Debug, config.DryRun, config.Timeout)
 	client.SetEndpoint("simplehosting/")
 	return &SimpleHosting{client: *client}
 }


### PR DESCRIPTION
This allows the API user to specify a timeout when talking to the Gandi API. When not set in the config it defaults to 5 seconds.