### PR TITLE
Add email auto renew

### DIFF
--- a/email/types.go
+++ b/email/types.go
@@ -31,6 +31,7 @@ type MailboxResponse struct {
 		Message string `json:"message"`
 		Enabled bool   `json:"enabled"`
 	} `json:"responder"`
+	ExpiresAt   time.Time `json:"expires_at"`
 	MailboxType string   `json:"mailbox_type"`
 	Login       string   `json:"login"`
 	QuotaUsed   int      `json:"quota_used"`

--- a/email/types.go
+++ b/email/types.go
@@ -26,20 +26,20 @@ type ListMailboxResponse struct {
 
 // MailboxResponse mailbox parameters
 type MailboxResponse struct {
-	Domain    string `json:"domain"`
+	Address     string    `json:"address"`
+	Aliases     []string  `json:"aliases"`
+	Antispam    bool      `json:"antispam"`
+	Domain      string    `json:"domain"`
+	ExpiresAt   time.Time `json:"expires_at"`
+	Href        string    `json:"href"`
+	ID          string    `json:"id"`
+	Login       string    `json:"login"`
+	MailboxType string    `json:"mailbox_type"`
+	QuotaUsed   int       `json:"quota_used"`
 	Responder struct {
 		Message string `json:"message"`
 		Enabled bool   `json:"enabled"`
 	} `json:"responder"`
-	ExpiresAt   time.Time `json:"expires_at"`
-	MailboxType string   `json:"mailbox_type"`
-	Login       string   `json:"login"`
-	QuotaUsed   int      `json:"quota_used"`
-	Aliases     []string `json:"aliases"`
-	Address     string   `json:"address"`
-	Href        string   `json:"href"`
-	ID          string   `json:"id"`
-	Antispam    bool     `json:"antispam"`
 }
 
 // CreateEmailRequest create mailbox request

--- a/email/types.go
+++ b/email/types.go
@@ -15,6 +15,11 @@ type Email struct {
 type ListMailboxResponse struct {
 	Address     string    `json:"address"`
 	Antispam    bool      `json:"antispam"`
+	Autorenew   struct {
+		Duration      int    `json:"duration"`
+		DurationType  string `json:"duration_type"`
+		Enabled       bool   `json:"enabled"`
+	} `json:"autorenew"`
 	Domain      string    `json:"domain"`
 	ExpiresAt   time.Time `json:"expires_at"`
 	Href        string    `json:"href"`
@@ -29,6 +34,11 @@ type MailboxResponse struct {
 	Address     string    `json:"address"`
 	Aliases     []string  `json:"aliases"`
 	Antispam    bool      `json:"antispam"`
+	Autorenew   struct {
+		Duration      int    `json:"duration"`
+		DurationType  string `json:"duration_type"`
+		Enabled       bool   `json:"enabled"`
+	} `json:"autorenew"`
 	Domain      string    `json:"domain"`
 	ExpiresAt   time.Time `json:"expires_at"`
 	Href        string    `json:"href"`

--- a/email/types.go
+++ b/email/types.go
@@ -13,12 +13,12 @@ type Email struct {
 
 // ListMailboxResponse describes mailbox
 type ListMailboxResponse struct {
-	Address     string    `json:"address"`
-	Antispam    bool      `json:"antispam"`
-	Autorenew   struct {
-		Duration      int    `json:"duration"`
-		DurationType  string `json:"duration_type"`
-		Enabled       bool   `json:"enabled"`
+	Address   string `json:"address"`
+	Antispam  bool   `json:"antispam"`
+	Autorenew struct {
+		Duration     int    `json:"duration"`
+		DurationType string `json:"duration_type"`
+		Enabled      bool   `json:"enabled"`
 	} `json:"autorenew"`
 	Domain      string    `json:"domain"`
 	ExpiresAt   time.Time `json:"expires_at"`
@@ -31,13 +31,13 @@ type ListMailboxResponse struct {
 
 // MailboxResponse mailbox parameters
 type MailboxResponse struct {
-	Address     string    `json:"address"`
-	Aliases     []string  `json:"aliases"`
-	Antispam    bool      `json:"antispam"`
-	Autorenew   struct {
-		Duration      int    `json:"duration"`
-		DurationType  string `json:"duration_type"`
-		Enabled       bool   `json:"enabled"`
+	Address   string   `json:"address"`
+	Aliases   []string `json:"aliases"`
+	Antispam  bool     `json:"antispam"`
+	Autorenew struct {
+		Duration     int    `json:"duration"`
+		DurationType string `json:"duration_type"`
+		Enabled      bool   `json:"enabled"`
 	} `json:"autorenew"`
 	Domain      string    `json:"domain"`
 	ExpiresAt   time.Time `json:"expires_at"`
@@ -46,7 +46,7 @@ type MailboxResponse struct {
 	Login       string    `json:"login"`
 	MailboxType string    `json:"mailbox_type"`
 	QuotaUsed   int       `json:"quota_used"`
-	Responder struct {
+	Responder   struct {
 		Message string `json:"message"`
 		Enabled bool   `json:"enabled"`
 	} `json:"responder"`


### PR DESCRIPTION
The `autorenew` attribute has been added to the mailbox response: https://api.gandi.net/docs/email/#get-v5-email-mailboxes-domain

I also added the `ExpiredAt` attribute to the `MailboxResponse` (forgot it in  https://github.com/go-gandi/go-gandi/pull/77).

